### PR TITLE
use node 12.x

### DIFF
--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -64,7 +64,7 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version=${1:-10.x}
+  local version=${1:-12.x}
   local dir="${2:?}"
   local code os cpu resolve_result
 


### PR DESCRIPTION
Fixes deployment problems with underwriter, now that `instant_order_app` is part of the yarn workspace, and the workspace requires node 12.x.