### PR TITLE
Fix instant order app build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -140,8 +140,9 @@ install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
 
   if [ -d "$BUILD_DIR/instant_order_app" ]; then
     echo "instant_order_app found. Running yarn install and yarn build." | indent
-    yarn --cwd "$BUILD_DIR/instant_order_app" install
-    yarn --cwd "$BUILD_DIR/instant_order_app" build
+    yarn install
+    yarn workspace @shared/components build
+    yarn workspace instant_order_app build
   fi
 
 else

--- a/bin/compile
+++ b/bin/compile
@@ -126,6 +126,14 @@ install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
 ##  pwd
 #fi
 
+  yarn install
+
+  if [ -d "$BUILD_DIR/instant_order_app" ]; then
+    echo "instant_order_app found. Running yarn install and yarn build." | indent
+    yarn workspace @shared/components build
+    yarn workspace instant_order_app build
+  fi
+
   if [ -d "$BUILD_DIR/lender_onboarding_ui" ]; then
     echo "lender_onboarding_ui found. Running yarn install and yarn build." | indent
     yarn --cwd "$BUILD_DIR/lender_onboarding_ui" install
@@ -136,13 +144,6 @@ install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
     echo "integration_admin_ui found. Running yarn install and yarn build." | indent
     yarn --cwd "$BUILD_DIR/integration_admin_ui" install
     yarn --cwd "$BUILD_DIR/integration_admin_ui" build
-  fi
-
-  if [ -d "$BUILD_DIR/instant_order_app" ]; then
-    echo "instant_order_app found. Running yarn install and yarn build." | indent
-    yarn install
-    yarn workspace @shared/components build
-    yarn workspace instant_order_app build
   fi
 
 else

--- a/bin/compile
+++ b/bin/compile
@@ -126,14 +126,6 @@ install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
 ##  pwd
 #fi
 
-  yarn install
-
-  if [ -d "$BUILD_DIR/instant_order_app" ]; then
-    echo "instant_order_app found. Running yarn install and yarn build." | indent
-    yarn workspace @shared/components build
-    yarn workspace instant_order_app build
-  fi
-
   if [ -d "$BUILD_DIR/lender_onboarding_ui" ]; then
     echo "lender_onboarding_ui found. Running yarn install and yarn build." | indent
     yarn --cwd "$BUILD_DIR/lender_onboarding_ui" install
@@ -145,6 +137,17 @@ install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
     yarn --cwd "$BUILD_DIR/integration_admin_ui" install
     yarn --cwd "$BUILD_DIR/integration_admin_ui" build
   fi
+
+  if [ -d "$BUILD_DIR/instant_order_app" ]; then
+    echo "instant_order_app found. Running yarn install and yarn build." | indent
+    yarn install
+    yarn --cwd "$BUILD_DIR/@shared/components" build
+    yarn --cwd "$BUILD_DIR/instant_order_app" build
+  fi
+
+  # clear out the node_modules now that the build is finished
+  # since everything that was built is now static files
+  find "$BUILD_DIR" -type d -name node_modules -prune -exec rm -rf {} \;
 
 else
   echo "No project found. Skipping yarn install and yarn build." | indent

--- a/bin/compile
+++ b/bin/compile
@@ -141,7 +141,7 @@ install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
   if [ -d "$BUILD_DIR/instant_order_app" ]; then
     echo "instant_order_app found. Running yarn install and yarn build." | indent
     yarn install
-    yarn --cwd "$BUILD_DIR/@shared/components" build
+    yarn --cwd "$BUILD_DIR/ts_shared/components" build
     yarn --cwd "$BUILD_DIR/instant_order_app" build
   fi
 

--- a/lib/environment.sh
+++ b/lib/environment.sh
@@ -23,6 +23,8 @@ create_default_env() {
   export NODE_MODULES_CACHE=${NODE_MODULES_CACHE:-true}
   export NODE_ENV=${NODE_ENV:-production}
   export NODE_VERBOSE=${NODE_VERBOSE:-false}
+  # StatesTitle/cplummer - don't block devDependencies from installing
+  export YARN_PRODUCTION=${YARN_PRODUCTION:-false}
 }
 
 create_build_env() {


### PR DESCRIPTION
* Use YARN_PRODUCTION=false by default to install dev dependencies
* Build ts_shared/components along with instant_order_app
* Delete node_modules after building since we don't need them anymore and the slug size is too large