### PR TITLE
bin/compile: add shared logger installation and build step

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -126,6 +126,12 @@ install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
 ##  pwd
 #fi
 
+  if [ -d "$BUILD_DIR/ts_shared/logger" ]; then
+    echo "ts_shared/logger found. Running yarn install and yarn build." | indent
+    yarn --cwd "$BUILD_DIR/ts_shared/logger" install
+    yarn --cwd "$BUILD_DIR/ts_shared/logger" build
+  fi
+
   if [ -d "$BUILD_DIR/lender_onboarding_ui" ]; then
     echo "lender_onboarding_ui found. Running yarn install and yarn build." | indent
     yarn --cwd "$BUILD_DIR/lender_onboarding_ui" install


### PR DESCRIPTION
Underwriter builds are failing - related to the new `@shared/logger` installations.
Here's one: https://circleci.com/gh/StatesTitle/underwriter/82479

This change updates `bin/compile` to install and build the logger before everything else.

I'm pretty sure this is the thing to do, but please let me know if I'm missing something - I'm not familiar with this codebase.