### PR TITLE
Use read_json to get node and yarn version numbers for install

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,7 @@ source "$BP_DIR/lib/failure.sh"
 # shellcheck source=lib/binaries.sh
 source "$BP_DIR/lib/binaries.sh"
 ## shellcheck source=lib/json.sh
-#source "$BP_DIR/lib/json.sh"
+source "$BP_DIR/lib/json.sh"
 ## shellcheck source=lib/cache.sh
 #source "$BP_DIR/lib/cache.sh"
 ## shellcheck source=lib/dependencies.sh

--- a/bin/compile
+++ b/bin/compile
@@ -94,8 +94,8 @@ create_env # can't pipe the whole thing because piping causes subshells, prevent
 list_node_config | output "$LOG_FILE"
 create_build_env
 
-install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node"
-install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine"
+install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node" "$BUILD_DIR"
+install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine" "$BUILD_DIR"
 
 ######################################
 # End part copied from heroku/nodejs #

--- a/bin/compile
+++ b/bin/compile
@@ -94,8 +94,8 @@ create_env # can't pipe the whole thing because piping causes subshells, prevent
 list_node_config | output "$LOG_FILE"
 create_build_env
 
-install_nodejs "$node_engine" "$BUILD_DIR/.heroku/node" "$BUILD_DIR"
-install_yarn "$BUILD_DIR/.heroku/yarn" "$yarn_engine" "$BUILD_DIR"
+install_nodejs "$BUILD_DIR/.heroku/node" "$BUILD_DIR"
+install_yarn "$BUILD_DIR/.heroku/yarn" "$BUILD_DIR"
 
 ######################################
 # End part copied from heroku/nodejs #

--- a/bin/compile
+++ b/bin/compile
@@ -53,7 +53,7 @@ source "$BP_DIR/lib/environment.sh"
 source "$BP_DIR/lib/failure.sh"
 # shellcheck source=lib/binaries.sh
 source "$BP_DIR/lib/binaries.sh"
-## shellcheck source=lib/json.sh
+# shellcheck source=lib/json.sh
 source "$BP_DIR/lib/json.sh"
 ## shellcheck source=lib/cache.sh
 #source "$BP_DIR/lib/cache.sh"

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -34,7 +34,8 @@ resolve() {
 
 install_yarn() {
   local dir="$1"
-  local version=$(read_json "$dir/package.json" ".engines.yarn")
+  local build_dir="$3"
+  local version=$(read_json "$build_dir/package.json" ".engines.yarn")
   local number url code resolve_result
 
   echo "Resolving yarn version $version..."
@@ -64,8 +65,8 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local build_dir="$2"
   local dir="${2:?}"
+  local build_dir="$3"
   local version=$(read_json "$build_dir/package.json" ".engines.node")
   local code os cpu resolve_result
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -64,7 +64,7 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local build_dir="$1"
+  local build_dir="$2"
   local dir="${2:?}"
   local version=$(read_json "$build_dir/package.json" ".engines.node")
   local code os cpu resolve_result

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -34,7 +34,7 @@ resolve() {
 
 install_yarn() {
   local dir="$1"
-  local version='1.22.5'
+  local version=$(read_json "$dir/package.json" ".engines.yarn")
   local number url code resolve_result
 
   echo "Resolving yarn version $version..."
@@ -64,8 +64,8 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local version='12.19.0'
   local dir="${2:?}"
+  local version=$(read_json "$dir/package.json" ".engines.node")
   local code os cpu resolve_result
 
   os=$(get_os)

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -34,7 +34,7 @@ resolve() {
 
 install_yarn() {
   local dir="$1"
-  local build_dir="$3"
+  local build_dir="$2"
   local version=$(read_json "$build_dir/package.json" ".engines.yarn")
   local number url code resolve_result
 
@@ -65,8 +65,8 @@ install_yarn() {
 }
 
 install_nodejs() {
-  local dir="${2:?}"
-  local build_dir="$3"
+  local dir="${1:?}"
+  local build_dir="$2"
   local version=$(read_json "$build_dir/package.json" ".engines.node")
   local code os cpu resolve_result
 

--- a/lib/binaries.sh
+++ b/lib/binaries.sh
@@ -64,8 +64,9 @@ install_yarn() {
 }
 
 install_nodejs() {
+  local build_dir="$1"
   local dir="${2:?}"
-  local version=$(read_json "$dir/package.json" ".engines.node")
+  local version=$(read_json "$build_dir/package.json" ".engines.node")
   local code os cpu resolve_result
 
   os=$(get_os)

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+JQ="/usr/bin/jq"
+if ! test -f "$JQ"; then
+  curl -Ls https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > "/usr/bin/jq" \
+      && chmod +x "/usr/bin/jq"
+fi
+
+read_json() {
+  local file="$1"
+  local key="$2"
+
+  if test -f "$file"; then
+    # -c = print on only one line
+    # -M = strip any color
+    # --raw-output = if the filter’s result is a string then it will be written directly
+    #                to stdout rather than being formatted as a JSON string with quotes
+    # shellcheck disable=SC2002
+    cat "$file" | $JQ -c -M --raw-output "$key // \"\"" || return 1
+  else
+    echo ""
+  fi
+}
+
+json_has_key() {
+  local file="$1"
+  local key="$2"
+
+  if test -f "$file"; then
+    # shellcheck disable=SC2002
+    cat "$file" | $JQ ". | has(\"$key\")"
+  else
+    echo "false"
+  fi
+}
+
+has_script() {
+  local file="$1"
+  local key="$2"
+
+  if test -f "$file"; then
+    # shellcheck disable=SC2002
+    cat "$file" | $JQ ".[\"scripts\"] | has(\"$key\")"
+  else
+    echo "false"
+  fi
+}
+
+is_invalid_json_file() {
+  local file="$1"
+  # shellcheck disable=SC2002
+  if ! cat "$file" | $JQ "." 1>/dev/null; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+


### PR DESCRIPTION
Node and yarn versions were hard coded to `12.19.0` and `1.22.5` respectively. This caused problems when those versions were updated in underwriter, since the versions downloaded via the buildpack were older than what underwriter and its various projects were expecting.

By bringing in `read_json` from [heroku-buildpack-nodejs](https://github.com/heroku/heroku-buildpack-nodejs/blob/41d6641ecf23582b0ae708f1940ab35c34eb5fdb/lib/json.sh) we can get the node and yarn versions dynamically from underwriter's root `package.json` file.

Tested this by creating a [copy](https://dashboard.heroku.com/apps/st-underwriter--buildpack-test) of `st-underwriter--staging` on heroku and using this branch as part of the buildpack settings and then pushing an underwriter branch directly to the copied heroku app. Verified that the new node and yarn versions were read and installed correctly. 